### PR TITLE
Updating to use expo 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This plugin will automatically configure your native code when it's generated (e
 
 Ensure you use versions that work together!
 
-| `expo` | `@daily-co/react-native-webrtc` | `@config-plugins/react-native-webrtc` | `@daily-co/react-native-daily-js` |`@daily-co/config-plugin-rn-daily-js` |
-|--------|---------------------------------|---------------------------------------| --------------------------------- |------------------------------------- |
-| 47.x   | 1.94.1-daily.8                  | 5.0.0                                 | 0.36.0                            |0.0.1                                 |
+| `expo` | `@daily-co/react-native-webrtc` | `@config-plugins/react-native-webrtc` | `@daily-co/react-native-daily-js` | `@daily-co/config-plugin-rn-daily-js` |
+|--------|---------------------------------|---------------------------------------|-----------------------------------|---------------------------------------|
+| 48.x   | 111.0.0-daily.1                 | 6.0.0                                 | 0.43.0                            | 0.0.2                                 |
+| 47.x   | 1.94.1-daily.8                  | 5.0.0                                 | 0.36.0                            | 0.0.1                                 |
 
 
 ## Expo installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daily-co/config-plugin-rn-daily-js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Config plugin to setup react-native-daily-js on prebuild",
   "main": "build/withDaily.js",
   "types": "build/withDaily.d.ts",
@@ -25,7 +25,7 @@
     "preset": "expo-module-scripts"
   },
   "peerDependencies": {
-    "expo": "^47.0.3"
+    "expo": "^48.0.15"
   },
   "devDependencies": {
     "expo-module-scripts": "^3.0.3"


### PR DESCRIPTION
Updating to use expo 48.

Need to publish a new version of the plugin once It is approved.