### PR TITLE
Fix app store compliance issues

### DIFF
--- a/src/withIosBroadcastExtension.ts
+++ b/src/withIosBroadcastExtension.ts
@@ -183,6 +183,7 @@ const addXCConfigurationList = (
     CLANG_WARN_UNGUARDED_AVAILABILITY: 'YES_AGGRESSIVE',
     // CODE_SIGN_ENTITLEMENTS: `${appName}/${appName}.entitlements`,
     CODE_SIGN_STYLE: 'Automatic',
+    ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: 'YES',
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     GCC_C_LANGUAGE_STANDARD: 'gnu11',
     GENERATE_INFOPLIST_FILE: 'YES',
@@ -401,15 +402,6 @@ const addBuildPhases = (
     buildPath
   );
   console.log(`Added PBXFrameworksBuildPhase ${replayKitFrameworksBuildPhaseUuid}`);
-  const { uuid: dailyFrameworksBuildPhaseUuid } = proj.addBuildPhase(
-      [frameworkPaths.dailyScreenShare],
-      'PBXCopyFilesBuildPhase',
-      'Frameworks',
-      targetUuid,
-      'app_extension',
-      buildPath
-  );
-  console.log(`Added PBXCopyFilesBuildPhase ${dailyFrameworksBuildPhaseUuid}`);
 
   // Resources build phase
   const { uuid: resourcesBuildPhaseUuid } = proj.addBuildPhase(


### PR DESCRIPTION
Fixes multiple issues that prevent anybody from publishing an app with this plugin to the app store (via expo eas).

Tested after these changes and we are able to publish as well as screenshare from a testflight build.

<details>
<summary>Error from before this PR</summary>


```
Starting the submit process
Downloading archive
Preparing artifact
Verifying archive
Creating ascApiJsonKey.json file with ASC credentials
Submitting iOS app to TestFlight...
Submitting the app with fastlane pilot
-------------------
--- Step: pilot ---
-------------------
Creating authorization token for App Store Connect API
Ready to upload new build to TestFlight (App: xxxx)...
Going to upload updated app to App Store Connect
This might take a few minutes. Please don't interrupt the script.
[altool] 2025-06-06 17:20:24.774 *** Error: Validation failed Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: xxxx) (409)
[altool]  {

[altool]     NSLocalizedDescription = "Validation failed";

[altool]     NSLocalizedFailureReason = "Invalid Bundle. The bundle at 'xxxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: xxxx)";

[altool]     NSUnderlyingError = "Error Domain=IrisAPI Code=-19241 \"Validation failed\" UserInfo={status=409, detail=Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'., id=xxxx, code=STATE_ERROR.VALIDATION_ERROR, title=Validation failed, NSLocalizedFailureReason=Invalid Bundle. The bundle at 'xxxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'., NSLocalizedDescription=Validation failed}";

[altool]     "iris-code" = "STATE_ERROR.VALIDATION_ERROR";

[altool] }

Application Loader output above ^
[ContentDelivery.Uploader.xxx] Validation failed (409) Invalid directory. The bundle Payload/xxx.app/PlugIns/ScreenCaptureExtension.appex/PlugIns/ReactNativeDailyJSScreenShareExtension.framework is not contained in a correctly named directory. It should be under Frameworks. (ID: xxx-x-x-x-xx)
[ContentDelivery.Uploader.x] Validation failed (409) CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'co.daily.ReactNativeDailyJSScreenShareExtension' under the iOS application 'xxxx.app'. (ID: x-x-x-x-x)
[ContentDelivery.Uploader.x] Validation failed (409) Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed nested bundles. (ID: xxx-x-x-x-x)
[ContentDelivery.Uploader.x] Validation failed (409) Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: x-xxx-xx-xxx-x)
Error uploading '/var/folders/m1/8_w9962s3b79dqm00nnlm85m0000gn/T/xx-xx-xx-xx-xxx.ipa'.
Validation failed Invalid directory. The bundle Payload/xxx.app/PlugIns/ScreenCaptureExtension.appex/PlugIns/ReactNativeDailyJSScreenShareExtension.framework is not contained in a correctly named directory. It should be under Frameworks. (ID: xxx-xx-xxx-xx-xx) (409)
Validation failed CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'co.daily.ReactNativeDailyJSScreenShareExtension' under the iOS application 'xxxx.app'. (ID: xxx-xxx-xxx-xxx-xxx) (409)
Validation failed Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed nested bundles. (ID: xxx-x-xx-xx-xx) (409)
Validation failed Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: xxxx-xxx-xxx-xx-xx) (409)
The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
Could not download/upload from App Store Connect!
[!] Error uploading ipa file: 
 [Application Loader Error Output]: [ContentDelivery.Uploader.x] Validation failed (409) Invalid directory. The bundle Payload/xxx.app/PlugIns/ScreenCaptureExtension.appex/PlugIns/ReactNativeDailyJSScreenShareExtension.framework is not contained in a correctly named directory. It should be under Frameworks. (ID: x-x-x-x-x)
[Application Loader Error Output]: [ContentDelivery.Uploader.x] Validation failed (409) CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'co.daily.ReactNativeDailyJSScreenShareExtension' under the iOS application 'xxxx.app'. (ID: x-x-x-x-x)
[Application Loader Error Output]: [ContentDelivery.Uploader.x] Validation failed (409) Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed nested bundles. (ID: x-x-x-x-x)
[Application Loader Error Output]: [ContentDelivery.Uploader.x] Validation failed (409) Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: x-d1fb-x-x-x)
[Application Loader Error Output]: Error uploading '/var/folders/m1/x/T/x-x-x-x-x.ipa'.
[Application Loader Error Output]: Validation failed Invalid directory. The bundle Payload/xxx.app/PlugIns/ScreenCaptureExtension.appex/PlugIns/ReactNativeDailyJSScreenShareExtension.framework is not contained in a correctly named directory. It should be under Frameworks. (ID: x-x-x-x-x) (409)
[Application Loader Error Output]: Validation failed CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'co.daily.ReactNativeDailyJSScreenShareExtension' under the iOS application 'xxxx.app'. (ID: x-x-x-x-x) (409)
[Application Loader Error Output]: Validation failed Invalid Bundle. The bundle at 'xxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed nested bundles. (ID: x-x-x-x-x) (409)
[Application Loader Error Output]: Validation failed Invalid Bundle. The bundle at 'xxxx.app/PlugIns/ScreenCaptureExtension.appex' contains disallowed file 'PlugIns'. (ID: x-x-x-x-x) (409)
[Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
Fastlane pilot failed
Failed to submit the app to the store
```


</details>